### PR TITLE
sample app needs Gemfile{.lock} for -b ruby_buildpack

### DIFF
--- a/fixtures/simple/Gemfile
+++ b/fixtures/simple/Gemfile
@@ -1,0 +1,2 @@
+source "https://rubygems.org"
+

--- a/fixtures/simple/Gemfile.lock
+++ b/fixtures/simple/Gemfile.lock
@@ -1,0 +1,11 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+
+BUNDLED WITH
+   1.15.4


### PR DESCRIPTION
I needed these two files to get the following command to run:

```
cf v3-push simple-apt -b https://github.com/cloudfoundry/apt-buildpack -b ruby_buildpack
```