### PR TITLE
Aptfile :repo: line add custom repositories

### DIFF
--- a/fixtures/simple/Aptfile
+++ b/fixtures/simple/Aptfile
@@ -1,1 +1,4 @@
 ascii
+:key:https://raw.githubusercontent.com/starkandwayne/homebrew-cf/master/public.key
+:repo:deb http://apt.starkandwayne.com stable main
+bosh-cli

--- a/fixtures/simple/app.rb
+++ b/fixtures/simple/app.rb
@@ -6,5 +6,9 @@ server.mount_proc '/' do |req, res|
   res.body = "Ascii: #{`ascii d`}"
 end
 
+server.mount_proc '/bosh' do |req, res|
+  res.body = "BOSH: #{`bosh2 -v`}"
+end
+
 trap("INT") { server.shutdown }
 server.start

--- a/src/apt/apt/apt_test.go
+++ b/src/apt/apt/apt_test.go
@@ -53,6 +53,7 @@ var _ = Describe("Apt", func() {
 				"-o", "dir::cache="+cacheDir+"/apt/cache",
 				"-o", "dir::state="+cacheDir+"/apt/state",
 				"-o", "dir::etc::sourcelist="+cacheDir+"/apt/sources/sources.list",
+				"-o", "dir::etc::trusted="+cacheDir+"/apt/etc/trusted.gpg",
 				"update",
 			).Return("Shell output", nil)
 
@@ -81,6 +82,7 @@ var _ = Describe("Apt", func() {
 				"-o", "dir::cache="+cacheDir+"/apt/cache",
 				"-o", "dir::state="+cacheDir+"/apt/state",
 				"-o", "dir::etc::sourcelist="+cacheDir+"/apt/sources/sources.list",
+				"-o", "dir::etc::trusted="+cacheDir+"/apt/etc/trusted.gpg",
 				"-y", "--force-yes", "-d", "install", "--reinstall",
 				"disneyland",
 			).Return("apt output", nil)

--- a/src/apt/apt/apt_test.go
+++ b/src/apt/apt/apt_test.go
@@ -52,6 +52,7 @@ var _ = Describe("Apt", func() {
 				"-o", "debug::nolocking=true",
 				"-o", "dir::cache="+cacheDir+"/apt/cache",
 				"-o", "dir::state="+cacheDir+"/apt/state",
+				"-o", "dir::etc::sourcelist="+cacheDir+"/apt/sources/sources.list",
 				"update",
 			).Return("Shell output", nil)
 
@@ -79,6 +80,7 @@ var _ = Describe("Apt", func() {
 				"-o", "debug::nolocking=true",
 				"-o", "dir::cache="+cacheDir+"/apt/cache",
 				"-o", "dir::state="+cacheDir+"/apt/state",
+				"-o", "dir::etc::sourcelist="+cacheDir+"/apt/sources/sources.list",
 				"-y", "--force-yes", "-d", "install", "--reinstall",
 				"disneyland",
 			).Return("apt output", nil)

--- a/src/apt/integration/deploy_test.go
+++ b/src/apt/integration/deploy_test.go
@@ -26,6 +26,7 @@ var _ = Describe("Apt supply buildpack", func() {
 
 			Expect(app.Stdout.String()).To(ContainSubstring("Installing apt packages"))
 			Expect(app.GetBody("/")).To(ContainSubstring("Ascii: ASCII 6/4 is decimal 100, hex 64"))
+			Expect(app.GetBody("/bosh")).To(ContainSubstring("BOSH: version 2"))
 		})
 	})
 


### PR DESCRIPTION
This PR adds the ability for a user to add custom repositories. It uses the same syntax as the https://elements.heroku.com/buildpacks/heroku/heroku-buildpack-apt

```
:repo:deb http://cz.archive.ubuntu.com/ubuntu artful main universe
```

Note: I'm unsure how to support custom repositories that have their own key, since `apt-key add` must be run as root. Any suggestions welcome.

For example, I cannot use http://apt.starkandwayne.com/ since it has its own public key. That is, the following line will fail:

```
:repo:deb http://apt.starkandwayne.com stable main
```

The buildpack error will be:
```
   W: GPG error: http://apt.starkandwayne.com stable Release: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY E8A5EA6A535EAEC4
```

Note to self from Slack:

![screen shot 2017-10-24 at 6 30 16 am](https://user-images.githubusercontent.com/108/31911698-e01c49de-b884-11e7-920a-9a905900ed2b.png)
