### PR TITLE
brats: use cached ruby buildpack instead of stack ruby

### DIFF
--- a/.github/.syncignore
+++ b/.github/.syncignore
@@ -1,0 +1,1 @@
+scripts/build-ruby-offline-bp.sh

--- a/src/apt/brats/brats_test.go
+++ b/src/apt/brats/brats_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Apt supply buildpack", func() {
 			Expect(aptYaml.Close()).To(Succeed())
 
 			app = cutlass.New(appDir)
-			app.Buildpacks = []string{bratshelper.Data.Uncached, "https://github.com/cloudfoundry/binary-buildpack#master"}
+			app.Buildpacks = []string{bratshelper.Data.Uncached, rubyBuildpackName, "https://github.com/cloudfoundry/binary-buildpack#master"}
 		})
 
 		It("runs", func() {

--- a/src/apt/integration/default_test.go
+++ b/src/apt/integration/default_test.go
@@ -31,7 +31,7 @@ func testDefault(platform switchblade.Platform, fixturePath string) func(*testin
 
 		it("supplies apt packages to later buildpacks", func() {
 			deployment, logs, err := platform.Deploy.
-				WithBuildpacks("apt_buildpack", "ruby_buildpack", "binary_buildpack").
+				WithBuildpacks("apt_buildpack", rubyBuildpackName, "binary_buildpack").
 				WithEnv(map[string]string{"BP_DEBUG": "1"}).
 				Execute(name, fixturePath)
 			Expect(err).NotTo(HaveOccurred())

--- a/src/apt/integration/init_test.go
+++ b/src/apt/integration/init_test.go
@@ -25,6 +25,7 @@ var settings struct {
 	Platform    string
 	Stack       string
 }
+var rubyTmpDir, rubyBuildpackName string
 
 func init() {
 	flag.BoolVar(&settings.Cached, "cached", false, "run cached buildpack tests")
@@ -71,7 +72,7 @@ func TestIntegration(t *testing.T) {
 		Expect(err).NotTo(HaveOccurred())
 	}
 
-	rubyTmpDir, err := os.MkdirTemp("", "ruby")
+	rubyTmpDir, err = os.MkdirTemp("", "ruby")
 	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to create tempdir: %v", err))
 
 	// We need a cached ruby-buildpack to run the simple web app in offline mode
@@ -81,8 +82,9 @@ func TestIntegration(t *testing.T) {
 	data, err := command.CombinedOutput()
 	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to create cached ruby_buildpack:\n%s\n%v", string(data), err))
 
+	rubyBuildpackName = fmt.Sprintf("%s_buildpack", filepath.Base(rubyTmpDir))
 	err = platform.Initialize(switchblade.Buildpack{
-		Name: "ruby_buildpack",
+		Name: rubyBuildpackName,
 		URI:  filepath.Join(rubyTmpDir, "ruby-buildpack.zip"),
 	})
 	Expect(err).NotTo(HaveOccurred())

--- a/src/apt/integration/private_repo_test.go
+++ b/src/apt/integration/private_repo_test.go
@@ -31,7 +31,7 @@ func testPrivateRepo(platform switchblade.Platform, fixturePath string) func(*te
 
 		it("doesn't navigate to Canonical", func() {
 			deployment, logs, err := platform.Deploy.
-				WithBuildpacks("apt_buildpack", "ruby_buildpack", "binary_buildpack").
+				WithBuildpacks("apt_buildpack", rubyBuildpackName, "binary_buildpack").
 				WithEnv(map[string]string{"BP_DEBUG": "1"}).
 				WithoutInternetAccess().
 				Execute(name, fixturePath)


### PR DESCRIPTION
similar to #133 which was for integration tests.
