### PR TITLE
Fix tests errors (cflinuxfs3 not included in cf envs)

### DIFF
--- a/fixtures/simple/apt.yml
+++ b/fixtures/simple/apt.yml
@@ -2,12 +2,12 @@
 truncatesources: true
 cleancache: true
 keys:
-- {{.repoBaseURL}}/gpg_public_key
+  - {{.repoBaseURL}}/gpg_public_key
 repos:
-- deb {{.repoBaseURL}} trusty main
-- name: deb {{.repoBaseURL}} trusty-backports main
-  priority: 100
+  - deb {{.repoBaseURL}} trusty main
+  - name: deb {{.repoBaseURL}} trusty-backports main
+    priority: 100
 packages:
-- {{.repoBaseURL}}/pool/main/j/jq/jq_1.5_amd64.deb
-- bosh-cli
-- cf-cli/trusty-backports
+  - {{.repoBaseURL}}/pool/main/j/jq/jq_1.5_amd64.deb
+  - bosh-cli
+  - cf-cli/trusty-backports

--- a/scripts/build-offline-bp.sh
+++ b/scripts/build-offline-bp.sh
@@ -12,10 +12,15 @@ source "${ROOTDIR}/scripts/.util/print.sh"
 function main() {
   local stack
   stack="cflinuxfs4"
-  outputDir="${ROOTDIR}/build/ruby-buildpack"
+  outputDir="${ROOTDIR}/build/buildpacks"
 
   while [[ "${#}" != 0 ]]; do
     case "${1}" in
+      --buildpack)
+        buildpack="${2}"
+        shift 2
+        ;;
+
       --stack)
         stack="${2}"
         shift 2
@@ -38,11 +43,11 @@ function main() {
 
   mkdir -p "${outputDir}"
   pushd "${outputDir}" > /dev/null
-    util::print::info "Dowloading ruby-buildpack..."
-    curl -sJL -o ruby_buildpack_src.zip "https://github.com/cloudfoundry/ruby-buildpack/archive/refs/heads/master.zip"
-    unzip -q ruby_buildpack_src.zip
-    cd ruby-buildpack-master
-    ./scripts/package.sh --version 1.2.3 --stack "${stack}" --cached --output "${outputDir}/ruby-buildpack.zip"
+    util::print::info "Dowloading ${buildpack} buildpack ..."
+    curl -sJL -o "${buildpack}_buildpack_src.zip" "https://github.com/cloudfoundry/${buildpack}-buildpack/archive/refs/heads/master.zip"
+    unzip -q "${buildpack}_buildpack_src.zip"
+    cd "${buildpack}-buildpack-master"
+    ./scripts/package.sh --version 1.2.3 --stack "${stack}" --cached --output "${outputDir}/${buildpack}-buildpack.zip"
   popd
 }
 

--- a/src/apt/integration/default_test.go
+++ b/src/apt/integration/default_test.go
@@ -31,7 +31,7 @@ func testDefault(platform switchblade.Platform, fixturePath string) func(*testin
 
 		it("supplies apt packages to later buildpacks", func() {
 			deployment, logs, err := platform.Deploy.
-				WithBuildpacks("apt_buildpack", rubyBuildpackName, "binary_buildpack").
+				WithBuildpacks("apt_buildpack", "ruby_buildpack", "binary_buildpack").
 				WithEnv(map[string]string{"BP_DEBUG": "1"}).
 				Execute(name, fixturePath)
 			Expect(err).NotTo(HaveOccurred())

--- a/src/apt/integration/private_repo_test.go
+++ b/src/apt/integration/private_repo_test.go
@@ -31,7 +31,7 @@ func testPrivateRepo(platform switchblade.Platform, fixturePath string) func(*te
 
 		it("doesn't navigate to Canonical", func() {
 			deployment, logs, err := platform.Deploy.
-				WithBuildpacks("apt_buildpack", rubyBuildpackName, "binary_buildpack").
+				WithBuildpacks("apt_buildpack", "ruby_buildpack", "binary_buildpack").
 				WithEnv(map[string]string{"BP_DEBUG": "1"}).
 				WithoutInternetAccess().
 				Execute(name, fixturePath)


### PR DESCRIPTION
Now that the new CF environments do not come with preloaded buildpacks in their `cflinuxfs3` version, when we try to run the apt Buildpack tests, they fail because they have a dependency on the `ruby`, `staticfile`, and `binary` buildpacks.

The `ruby` buildpack was already provided through a script called `scripts/build-ruby.offline-bp.sh`, which was responsible for locally packaging the buildpack in its desired version. I reused this logic with some minor changes to support any buildpack passed as a parameter to adjust the requirements of `staticfile` and `binary` when the stack is `cflinuxfs3`.
