### PR TITLE
Update reference to package script in brats

### DIFF
--- a/src/apt/brats/brats_suite_test.go
+++ b/src/apt/brats/brats_suite_test.go
@@ -40,7 +40,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 
 	// We need a cached ruby-buildpack to run the simple web app in offline mode
 	// This builds a cached ruby-builpack to ${tmpDir}/ruby-buidpack.zip
-	command := exec.Command("scripts/build-ruby-offline-bp.sh", "--stack", os.Getenv("CF_STACK"), "--outputDir", rubyTmpDir)
+	command := exec.Command("scripts/build-offline-bp.sh", "--buildpack", "ruby", "--stack", os.Getenv("CF_STACK"), "--outputDir", rubyTmpDir)
 	command.Dir = root
 	data, err := command.CombinedOutput()
 	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to create cached ruby_buildpack:\n%s\n%v", string(data), err))


### PR DESCRIPTION
The changes introduced in #185 did not take into account any other reference to the `build-ruby-offline-bp.sh`. The BRATS test suite uses that script. I updated the reference to the correct one.