### PR TITLE
Replace deprecated io/ioutil with modern os/io equivalents

### DIFF
--- a/src/apt/apt/apt_test.go
+++ b/src/apt/apt/apt_test.go
@@ -2,7 +2,6 @@ package apt_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -38,13 +37,13 @@ var _ = Describe("Apt", func() {
 		logger = libbuildpack.NewLogger(buffer)
 
 		aptFile = filepath.Join(bpDir, "fixtures", "unit", "aptFile.yml")
-		rootDir, _ = ioutil.TempDir("", "rootdir")
-		cacheDir, _ = ioutil.TempDir("", "cachedir")
-		installDir, _ = ioutil.TempDir("", "installdir")
+		rootDir, _ = os.MkdirTemp("", "rootdir")
+		cacheDir, _ = os.MkdirTemp("", "cachedir")
+		installDir, _ = os.MkdirTemp("", "installdir")
 
-		ioutil.WriteFile(filepath.Join(rootDir, "sources.list"), []byte(""), 0666)
-		ioutil.WriteFile(filepath.Join(rootDir, "trusted.gpg"), []byte(""), 0666)
-		ioutil.WriteFile(filepath.Join(rootDir, "preferences"), []byte(""), 0666)
+		os.WriteFile(filepath.Join(rootDir, "sources.list"), []byte(""), 0666)
+		os.WriteFile(filepath.Join(rootDir, "trusted.gpg"), []byte(""), 0666)
+		os.WriteFile(filepath.Join(rootDir, "preferences"), []byte(""), 0666)
 
 		mockCtrl = gomock.NewController(GinkgoT())
 		mockCommand = NewMockCommand(mockCtrl)
@@ -203,17 +202,17 @@ var _ = Describe("Apt", func() {
 
 				sourceList = filepath.Join(cacheDir, "apt", "sources", "sources.list")
 				Expect(os.MkdirAll(filepath.Dir(sourceList), 0777)).To(Succeed())
-				Expect(ioutil.WriteFile(sourceList, []byte("repo 1\nrepo 2"), 0666)).To(Succeed())
+				Expect(os.WriteFile(sourceList, []byte("repo 1\nrepo 2"), 0666)).To(Succeed())
 
 				prefFile = filepath.Join(cacheDir, "apt", "etc", "preferences")
 				Expect(os.MkdirAll(filepath.Dir(prefFile), 0777)).To(Succeed())
-				Expect(ioutil.WriteFile(prefFile, []byte("Package: *\nPin: release a=repo 1\nPin-Priority"), 0666)).To(Succeed())
+				Expect(os.WriteFile(prefFile, []byte("Package: *\nPin: release a=repo 1\nPin-Priority"), 0666)).To(Succeed())
 			})
 
 			It("adds the repos to the apt sources list", func() {
 				Expect(a.AddRepos()).To(Succeed())
 
-				content, err := ioutil.ReadFile(sourceList)
+				content, err := os.ReadFile(sourceList)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(string(content)).To(Equal("repo 1\nrepo 2\nrepo 11\nrepo 12\nrepo 13"))
 			})
@@ -221,7 +220,7 @@ var _ = Describe("Apt", func() {
 			It("adds repo priorities to the preferences file", func() {
 				Expect(a.AddRepos()).To(Succeed())
 
-				content, err := ioutil.ReadFile(prefFile)
+				content, err := os.ReadFile(prefFile)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(string(content)).To(Equal("Package: *\nPin: release a=repo 1\nPin-Priority\nPackage: *\nPin: release a=repo 12\nPin-Priority: 99\n\nPackage: *\nPin: release a=repo 13\nPin-Priority: 100\n"))
 			})
@@ -321,11 +320,11 @@ var _ = Describe("Apt", func() {
 	Describe("InstallAll", func() {
 		BeforeEach(func() {
 			var err error
-			cacheDir, err = ioutil.TempDir("", "cachedir")
+			cacheDir, err = os.MkdirTemp("", "cachedir")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(os.MkdirAll(filepath.Join(cacheDir, "apt", "cache", "archives"), 0755)).To(Succeed())
-			Expect(ioutil.WriteFile(filepath.Join(cacheDir, "apt", "cache", "archives", "holiday.deb"), []byte{}, 0644)).To(Succeed())
-			Expect(ioutil.WriteFile(filepath.Join(cacheDir, "apt", "cache", "archives", "disneyland.deb"), []byte{}, 0644)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(cacheDir, "apt", "cache", "archives", "holiday.deb"), []byte{}, 0644)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(cacheDir, "apt", "cache", "archives", "disneyland.deb"), []byte{}, 0644)).To(Succeed())
 		})
 
 		It("installs the downloaded debs", func() {

--- a/src/apt/supply/supply.go
+++ b/src/apt/supply/supply.go
@@ -1,7 +1,6 @@
 package supply
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -117,7 +116,7 @@ func (s *Supplier) createSymlinks() error {
 		if exists, err := libbuildpack.FileExists(dest); err != nil {
 			return err
 		} else if exists {
-			files, err := ioutil.ReadDir(dest)
+			files, err := os.ReadDir(dest)
 			if err != nil {
 				return err
 			}
@@ -127,12 +126,12 @@ func (s *Supplier) createSymlinks() error {
 			}
 			for _, file := range files {
 				//TODO: better way to copy a file?
-				contents, err := ioutil.ReadFile(filepath.Join(dest, file.Name()))
+				contents, err := os.ReadFile(filepath.Join(dest, file.Name()))
 				if err != nil {
 					return err
 				}
 				newContents := strings.Replace(string(contents[:]), "prefix=/usr\n", "prefix="+filepath.Join(s.Stager.DepDir(), "apt", "usr")+"\n", -1)
-				err = ioutil.WriteFile(filepath.Join(destDir, file.Name()), []byte(newContents), 0666)
+				err = os.WriteFile(filepath.Join(destDir, file.Name()), []byte(newContents), 0666)
 				if err != nil {
 					return err
 				}

--- a/src/apt/supply/supply_test.go
+++ b/src/apt/supply/supply_test.go
@@ -1,7 +1,6 @@
 package supply_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -36,7 +35,7 @@ var _ = Describe("Supply", func() {
 
 		mockCtrl = gomock.NewController(GinkgoT())
 		mockStager = NewMockStager(mockCtrl)
-		depDir, err = ioutil.TempDir("", "apt.depdir")
+		depDir, err = os.MkdirTemp("", "apt.depdir")
 		Expect(err).ToNot(HaveOccurred())
 		mockStager.EXPECT().DepDir().AnyTimes().Return(depDir)
 		mockApt = NewMockApt(mockCtrl)


### PR DESCRIPTION
## Summary

- Replaces all `ioutil.ReadFile`, `WriteFile`, `ReadDir`, `TempDir`, `TempFile`, `ReadAll`, and `Discard` calls with their Go 1.16+ equivalents in the `os` and `io` packages
- Removes the `io/ioutil` import from all affected files

## Motivation

`io/ioutil` was deprecated in Go 1.16. All buildpacks now target Go 1.24.x, so these modern replacements are fully supported.

## Related

Part of a series of identical PRs across all CF buildpacks and libbuildpack (see cloudfoundry/libbuildpack#211).