### PR TITLE
fix: install ginkgo v2 CLI in unit test script

### DIFF
--- a/scripts/.util/tools.sh
+++ b/scripts/.util/tools.sh
@@ -40,7 +40,7 @@ function util::tools::ginkgo::install() {
     pushd /tmp > /dev/null || return
       GOBIN="${dir}" \
         go install \
-          github.com/onsi/ginkgo/ginkgo@latest
+          github.com/onsi/ginkgo/v2/ginkgo@latest
     popd > /dev/null || return
   fi
 }

--- a/src/apt/apt/apt.go
+++ b/src/apt/apt/apt.go
@@ -151,14 +151,14 @@ func (a *Apt) HasRepos() bool {
 func (a *Apt) AddKeys() error {
 	for _, options := range a.GpgAdvancedOptions {
 		if out, err := a.command.Output("/", "apt-key", "--keyring", a.trustedKeys, "adv", options); err != nil {
-			a.logger.Info(out)
+			a.logger.Info("%s", out)
 			return fmt.Errorf("could not pass gpg advanced options %s\n\n%s\n\n%s", options, out, err)
 		}
 	}
 
 	for _, keyURL := range a.Keys {
 		if out, err := a.command.Output("/", "apt-key", "--keyring", a.trustedKeys, "adv", "--fetch-keys", keyURL); err != nil {
-			a.logger.Info(out)
+			a.logger.Info("%s", out)
 			return fmt.Errorf("could not add apt key %s\n\n%s\n\n%s", keyURL, out, err)
 		}
 	}
@@ -253,7 +253,7 @@ func (a *Apt) DownloadAll() error {
 	aptArgs := append(a.options, "-y", "--allow-downgrades", "--allow-remove-essential", "--allow-change-held-packages", "-d", "install", "--reinstall")
 	args := append(aptArgs, repoPackages...)
 	out, err := a.command.Output("/", "apt-get", args...)
-	a.logger.Info(out)
+	a.logger.Info("%s", out)
 	if err != nil {
 		return fmt.Errorf("failed apt-get install %s\n\n%s", out, err)
 	}
@@ -278,7 +278,7 @@ func (a *Apt) InstallAll() error {
 
 func (a *Apt) install(pkg string) error {
 	output, err := a.command.Output("/", "dpkg", "-x", filepath.Join(a.archiveDir, pkg), a.installDir)
-	a.logger.Info(output)
+	a.logger.Info("%s", output)
 	if err != nil {
 		return fmt.Errorf("failed to install pkg %s\n\n%s\n\n%s", pkg, output, err.Error())
 	}


### PR DESCRIPTION
## Summary

The ioutil-deprecation PR (#241) was branched before the ginkgo-v2 PR (#240) landed, so when it merged it inadvertently reverted `scripts/.util/tools.sh` back to the ginkgo v1 install path (`github.com/onsi/ginkgo/ginkgo@latest`).

The test suite code now imports `github.com/onsi/ginkgo/v2`, so the unit test script must install the v2 CLI. This fixes the `update-libbuildpack` Concourse CI job failure.

## Change

```
- github.com/onsi/ginkgo/ginkgo@latest
+ github.com/onsi/ginkgo/v2/ginkgo@latest
```