### PR TITLE
Fix cflinuxfs5 integration test: always upload staticfile and binary buildpacks

### DIFF
--- a/src/apt/integration/init_test.go
+++ b/src/apt/integration/init_test.go
@@ -62,25 +62,23 @@ func TestIntegration(t *testing.T) {
 	)
 	Expect(err).NotTo(HaveOccurred())
 
-	if os.Getenv("CF_STACK") == "cflinuxfs3" || settings.Platform == "docker" {
-		staticfileBuildpackFolder, err = prepareRequiredBuildpack("staticfile", root)
-		Expect(err).NotTo(HaveOccurred())
+	staticfileBuildpackFolder, err = prepareRequiredBuildpack("staticfile", root)
+	Expect(err).NotTo(HaveOccurred())
 
-		binaryBuildpackFolder, err = prepareRequiredBuildpack("binary", root)
-		Expect(err).NotTo(HaveOccurred())
+	binaryBuildpackFolder, err = prepareRequiredBuildpack("binary", root)
+	Expect(err).NotTo(HaveOccurred())
 
-		err = platform.Initialize(
-			switchblade.Buildpack{
-				Name: "staticfile_buildpack",
-				URI:  filepath.Join(staticfileBuildpackFolder, "staticfile-buildpack.zip"),
-			},
-			switchblade.Buildpack{
-				Name: "binary_buildpack",
-				URI:  filepath.Join(binaryBuildpackFolder, "binary-buildpack.zip"),
-			},
-		)
-		Expect(err).NotTo(HaveOccurred())
-	}
+	err = platform.Initialize(
+		switchblade.Buildpack{
+			Name: "staticfile_buildpack",
+			URI:  filepath.Join(staticfileBuildpackFolder, "staticfile-buildpack.zip"),
+		},
+		switchblade.Buildpack{
+			Name: "binary_buildpack",
+			URI:  filepath.Join(binaryBuildpackFolder, "binary-buildpack.zip"),
+		},
+	)
+	Expect(err).NotTo(HaveOccurred())
 
 	repoName, err := switchblade.RandomName()
 	Expect(err).NotTo(HaveOccurred())
@@ -113,10 +111,8 @@ func TestIntegration(t *testing.T) {
 	Expect(os.Remove(os.Getenv("BUILDPACK_FILE"))).To(Succeed())
 	Expect(os.RemoveAll(rubyBuildpackFolder)).To(Succeed())
 
-	if os.Getenv("CF_STACK") == "cflinuxfs3" {
-		Expect(os.RemoveAll(staticfileBuildpackFolder)).To(Succeed())
-		Expect(os.RemoveAll(binaryBuildpackFolder)).To(Succeed())
-	}
+	Expect(os.RemoveAll(staticfileBuildpackFolder)).To(Succeed())
+	Expect(os.RemoveAll(binaryBuildpackFolder)).To(Succeed())
 }
 
 func prepareRequiredBuildpack(buildpack, root string) (string, error) {


### PR DESCRIPTION
## Summary

- Fixes cflinuxfs5 integration test failure: `Buildpack "staticfile_buildpack" for stack "cflinuxfs5" must be an existing admin buildpack or a valid git URI`
- Removes the `CF_STACK == "cflinuxfs3"` conditional gate around `staticfile_buildpack` and `binary_buildpack` upload
- These buildpacks are now always prepared, uploaded, and cleaned up regardless of stack

## Context

The integration test unconditionally deploys a fixture app using `staticfile_buildpack` (via `.WithBuildpacks("staticfile_buildpack")`), but the upload of `staticfile_buildpack` and `binary_buildpack` was gated behind `os.Getenv("CF_STACK") == "cflinuxfs3" || settings.Platform == "docker"`.

On cflinuxfs4 this worked by accident because these buildpacks are pre-installed as admin buildpacks. On cflinuxfs5, they are not pre-installed (the cflinuxfs5 beta ops file only adds the stack, rootfs, and lifecycle — not admin buildpacks), so the test fails.

The fix removes the conditional entirely, matching the pattern used by `dotnet-core-buildpack` which also depends on `staticfile_buildpack` and always uploads it unconditionally. This is future-proof for any new stacks.